### PR TITLE
Fix many:many .has() utility

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1414,7 +1414,7 @@ class PromiseEdgeOrNullImpl<
     if (sourceId === null) {
       return null;
     }
-    const edgeDoc = this.ctx.db
+    const edgeDoc = await this.ctx.db
       .query(this.edgeDefinition.table)
       .withIndex(edgeCompoundIndexName(this.edgeDefinition), (q) =>
         (q.eq(this.edgeDefinition.field, sourceId as any) as any).eq(

--- a/test/convex/read.test.ts
+++ b/test/convex/read.test.ts
@@ -350,15 +350,27 @@ test("has many:many edge", async ({ ctx }) => {
   const messageId = await ctx
     .table("messages")
     .insert({ text: "Hello world", userId: userId });
+  const messageId2 = await ctx
+    .table("messages")
+    .insert({ text: "Hello to another world", userId: userId });
   const tagId = await ctx
     .table("tags")
     .insert({ name: "cool", messages: [messageId] });
+  const tagId2 = await ctx
+    .table("tags")
+    .insert({ name: "not-cool", messages: [] });
   expect(
     await ctx.table("messages").getX(messageId).edge("tags").has(tagId),
   ).toEqual(true);
   expect(
     await ctx.table("tags").getX(tagId).edge("messages").has(messageId),
   ).toEqual(true);
+  expect(
+    await ctx.table("tags").getX(tagId2).edge("messages").has(messageId2),
+  ).toEqual(false);
+  expect(
+    await ctx.table("messages").getX(messageId2).edge("tags").has(tagId2),
+  ).toEqual(false);
 });
 
 test("map many:many edge", async ({ ctx }) => {


### PR DESCRIPTION
<!-- Describe your PR here. -->

This utility always returns `true`. There was a missing `await` which means `Promise { <pending> } !== null` will always be true.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
